### PR TITLE
colorize "go test" output

### DIFF
--- a/colorizer.go
+++ b/colorizer.go
@@ -7,7 +7,7 @@ import (
 
 var buildRE, _ = regexp.Compile(`^(.*\.go)\:(\d*)\:(.*)\n?$`)
 
-func build(in string) (out string) {
+func buildOrTest(in string) (out string) {
 	matches := buildRE.FindStringSubmatch(in)
 	if len(matches) > 0 {
 		out = sgrBoldBlue(matches[1]) + ":" + sgrBoldRed(matches[2]) + ":" + matches[3] + "\n"

--- a/main.go
+++ b/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
-	"github.com/songgao/go.pipeline"
 	"os"
+
+	"github.com/songgao/go.pipeline"
 )
 
 var colorizers = map[string]pipeline.LineProcessor{
-	"build": build,
+	"build": buildOrTest,
+	"test":  buildOrTest,
 }
 
 func main() {


### PR DESCRIPTION
This pr colorizes build errors in `go test` output in the same way that `go build` output is colorized.

![screenshot 2015-06-25 13 34 42](https://cloud.githubusercontent.com/assets/640247/8364982/fbc3c38c-1b3e-11e5-9b8b-69bf0a867025.png)
