### PR TITLE
Enable color-output on windows

### DIFF
--- a/init_windows.go
+++ b/init_windows.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+    "os"
+
+    "golang.org/x/sys/windows"
+)
+
+func init() {
+    stdout := windows.Handle(os.Stdout.Fd())
+    var originalMode uint32
+
+    windows.GetConsoleMode(stdout, &originalMode)
+    windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}


### PR DESCRIPTION
Color output on windows needs to be enabled. Otherwise the raw control characters are shown.

Probably fixes #3 

Sources: 
- https://superuser.com/questions/413073/windows-console-with-ansi-colors-handling
- https://stackoverflow.com/questions/39627348/ansi-colours-on-windows-10-sort-of-not-working